### PR TITLE
Replace regex with pcre and fix for osx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,36 @@ name = "actors"
 version = "0.1.0"
 dependencies = [
  "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pcre 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bzip2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bzip2-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "enum-set"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -12,15 +40,45 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "regex"
-version = "0.1.33"
+name = "libpcre-sys"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex-syntax 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bzip2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tar 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.1.2"
+name = "log"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pcre"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "enum-set 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libpcre-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "tar"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/lib.rs"
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-regex = "0.1.8"
 libc = "0.1.8"
+pcre = "0.1.0" 

--- a/actors.rb
+++ b/actors.rb
@@ -4,7 +4,7 @@ require './imdb.rb'
 
 module RustWorld
   extend FFI::Library
-  ffi_lib 'target/release/libimdb.so'
+  ffi_lib 'target/release/libimdb.' + (RUBY_PLATFORM.include?('darwin') ? 'dylib' : 'so')
   attach_function :ffi_find_actors, [:string, :int, :string], :string
 end
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ use std::io::prelude::*;
 use std::io::BufReader;
 use std::fs::File;
 
-extern crate regex;
-use regex::Regex;
+extern crate pcre;
+use pcre::Pcre;
 
 extern crate libc;
 use libc::c_char;
@@ -31,7 +31,8 @@ pub fn find_actors(filename: String, skip_lines: usize, target_movie: String) ->
 
     let mut actor = String::new();
     let mut actors : Vec<String> = Vec::new();
-    let regex = Regex::new(r"^(.*?)\t+(.*?)$").unwrap();
+    let regex = Pcre::compile("^(.*?)\t+(.*?)$").unwrap();
+
     loop {
         let line = match reader.next() {
             Some(line) => match line {
@@ -41,10 +42,10 @@ pub fn find_actors(filename: String, skip_lines: usize, target_movie: String) ->
             None => break,
         };
 
-        match regex.captures(&line) {
+        match regex.exec(&line) {
             Some(captures) => {
-                let actor_buffer = captures.at(1).unwrap();
-                let movie        = captures.at(2).unwrap();
+                let actor_buffer = captures.group(1);
+                let movie        = captures.group(2);
 
                 if actor.is_empty() && !actor_buffer.is_empty() {
                     actor = actor_buffer.to_string();


### PR DESCRIPTION
pcre turns out to be somewhat faster. Also, ".so" won't work on osx so included a fix for that.
